### PR TITLE
Fix AddReferencedObject warning

### DIFF
--- a/Source/GridMapEditor/Private/GridMapEditorMode.h
+++ b/Source/GridMapEditor/Private/GridMapEditorMode.h
@@ -90,8 +90,8 @@ private:
 	bool bBrushTraceValid;
 	FVector BrushLocation;
 	FVector BrushTraceDirection;
-	TWeakObjectPtr<class AActor> BrushTraceHitActor;
-	UStaticMeshComponent* TileBrushComponent;
+       TWeakObjectPtr<class AActor> BrushTraceHitActor;
+       TObjectPtr<UStaticMeshComponent> TileBrushComponent;
 	/** The dynamic material of the tile brush. */
 	class UMaterialInstanceDynamic* BrushMID;
 	FColor BrushDefaultHighlightColor;


### PR DESCRIPTION
## Summary
- use `TObjectPtr` for `TileBrushComponent` to satisfy UE5 GC requirements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857cd3af3908320a5728c0ac53f0ef4