### PR TITLE
Integrate grid map toolbar with level editor

### DIFF
--- a/Source/GridMapEditor/Private/GridMapEditorModeToolkit.cpp
+++ b/Source/GridMapEditor/Private/GridMapEditorModeToolkit.cpp
@@ -3,10 +3,13 @@
 #include "GridMapEditorModeToolkit.h"
 #include "GridMapEditorMode.h"
 #include "GridMapEditorToolkitWidget.h"
+#include "GridMapEditCommands.h"
 #include "Engine/Selection.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Text/STextBlock.h"
 #include "EditorModeManager.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
+#include "LevelEditor.h"
 
 #define LOCTEXT_NAMESPACE "GridMapEditor"
 
@@ -16,8 +19,17 @@ FGridMapEditorModeToolkit::FGridMapEditorModeToolkit()
 
 void FGridMapEditorModeToolkit::Init(const TSharedPtr<IToolkitHost>& InitToolkitHost)
 {
-	ToolkitWidget = SNew(SGridMapEditorToolkitWidget);
-	FModeToolkit::Init(InitToolkitHost);
+        ToolkitWidget = SNew(SGridMapEditorToolkitWidget);
+        FModeToolkit::Init(InitToolkitHost);
+
+        if (FModuleManager::Get().IsModuleLoaded("LevelEditor"))
+        {
+                FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
+
+                ToolBarExtender = MakeShareable(new FExtender);
+                ToolBarExtender->AddToolBarExtension("Settings", EExtensionHook::After, GetToolkitCommands(), FToolBarExtensionDelegate::CreateRaw(this, &FGridMapEditorModeToolkit::ExtendLevelEditorToolBar));
+                LevelEditorModule.GetToolBarExtensibilityManager()->AddExtender(ToolBarExtender);
+        }
 }
 
 FName FGridMapEditorModeToolkit::GetToolkitFName() const
@@ -37,7 +49,21 @@ class FEdMode* FGridMapEditorModeToolkit::GetEditorMode() const
 
 TSharedPtr<class SWidget> FGridMapEditorModeToolkit::GetInlineContent() const
 {
-	return ToolkitWidget;
+        return ToolkitWidget;
+}
+
+TSharedPtr<SWidget> FGridMapEditorModeToolkit::BuildToolBar()
+{
+        FToolBarBuilder ToolbarBuilder(GetToolkitCommands(), FMultiBoxCustomization::None);
+        ExtendLevelEditorToolBar(ToolbarBuilder);
+        return ToolbarBuilder.MakeWidget();
+}
+
+void FGridMapEditorModeToolkit::ExtendLevelEditorToolBar(FToolBarBuilder& ToolbarBuilder)
+{
+        ToolbarBuilder.AddToolBarButton(FGridMapEditCommands::Get().SetPaintTiles);
+        ToolbarBuilder.AddToolBarButton(FGridMapEditCommands::Get().SetSelectTiles);
+        ToolbarBuilder.AddToolBarButton(FGridMapEditCommands::Get().SetTileSettings);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GridMapEditor/Private/GridMapEditorModeToolkit.h
+++ b/Source/GridMapEditor/Private/GridMapEditorModeToolkit.h
@@ -10,17 +10,22 @@ class FGridMapEditorModeToolkit : public FModeToolkit
 {
 public:
 
-	FGridMapEditorModeToolkit();
-	
-	/** FModeToolkit interface */
-	virtual void Init(const TSharedPtr<IToolkitHost>& InitToolkitHost) override;
+        FGridMapEditorModeToolkit();
+        virtual ~FGridMapEditorModeToolkit() {}
 
-	/** IToolkit interface */
-	virtual FName GetToolkitFName() const override;
-	virtual FText GetBaseToolkitName() const override;
-	virtual class FEdMode* GetEditorMode() const override;
-	virtual TSharedPtr<class SWidget> GetInlineContent() const override;
+        /** FModeToolkit interface */
+        virtual void Init(const TSharedPtr<IToolkitHost>& InitToolkitHost) override;
+        virtual TSharedPtr<SWidget> BuildToolBar() override;
+
+        /** IToolkit interface */
+        virtual FName GetToolkitFName() const override;
+        virtual FText GetBaseToolkitName() const override;
+        virtual class FEdMode* GetEditorMode() const override;
+        virtual TSharedPtr<class SWidget> GetInlineContent() const override;
 
 private:
-	TSharedPtr<class SGridMapEditorToolkitWidget> ToolkitWidget;
+        TSharedPtr<class SGridMapEditorToolkitWidget> ToolkitWidget;
+        TSharedPtr<class FExtender> ToolBarExtender;
+
+        void ExtendLevelEditorToolBar(struct FToolBarBuilder& ToolbarBuilder);
 };


### PR DESCRIPTION
## Summary
- add toolbar building logic to GridMap editor mode toolkit
- register a toolbar extender with Level Editor on initialization

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687414272430832084deadaa72b4407f